### PR TITLE
Also use XPC_SERVICE_NAME to detect Goland

### DIFF
--- a/golandreporter.go
+++ b/golandreporter.go
@@ -18,7 +18,7 @@ func NewGolandReporter() reporters.Reporter {
 }
 
 func NewAutoGolandReporter() reporters.Reporter {
-	if strings.Contains(os.Getenv("OLDPWD"), "Goland") {
+	if strings.Contains(os.Getenv("OLDPWD"), "Goland") || strings.Contains(os.Getenv("XPC_SERVICE_NAME"), "jetbrains") {
 		return NewGolandReporter()
 	} else {
 		stenographer := stenographer.New(!config.DefaultReporterConfig.NoColor, config.GinkgoConfig.FlakeAttempts > 1, os.Stdout)


### PR DESCRIPTION
The existing method wasn't working on my MacOS machine, but this new method does.

I open GoLand with the goland binary, which may alter the environment. It's also possible that the existing method works on Linux but not MacOS.